### PR TITLE
초기 닉네임/공개여부 설정 페이지 반응형 적용(mobile)

### DIFF
--- a/src/components/PrimaryButton/index.tsx
+++ b/src/components/PrimaryButton/index.tsx
@@ -27,11 +27,13 @@ const S = {
     width: 100%;
     line-height: 3rem;
     font-size: 2rem;
-    padding: 1.7rem 0;
+    padding: 1.4rem 0;
     border-radius: 0.6rem;
     @media ${device.mobile} {
       font-size: 1.6rem;
-      padding: 1.4rem 0;
+      position: absolute;
+      bottom: 3rem;
+      right: 0;
     }
   `,
 };

--- a/src/components/PrimaryInput/index.tsx
+++ b/src/components/PrimaryInput/index.tsx
@@ -37,6 +37,7 @@ const S = {
   `,
 
   Input: styled.input<{ $isInvalid: boolean }>`
+    font-family: 'Pretendard';
     border-bottom: ${({ $isInvalid }) => ($isInvalid ? 'var(--red400)' : 'var(--gray400)')} 1px solid;
     color: var(--gray800);
     width: 100%;
@@ -49,10 +50,12 @@ const S = {
     &::placeholder {
       color: var(--gray400);
       font-size: 1.4rem;
+      font-weight: 100;
     }
   `,
 
   InvalidMsg: styled.p`
+    font-family: 'Pretendard';
     position: absolute;
     bottom: -2.2rem;
     font-size: 1.4rem;

--- a/src/components/template/SettingTemplate.tsx
+++ b/src/components/template/SettingTemplate.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { device } from '@styles/breakpoints';
 import styled from 'styled-components';
 
 interface TSettingTemplateProps {
@@ -26,7 +27,15 @@ const S = {
     position: relative;
     display: flex;
     flex-direction: column;
-    width: 464px;
+    min-width: 46.4rem;
+    @media ${device.mobile} {
+      width: 100%;
+      min-width: 0;
+      margin: 3rem 2rem;
+      height: 100vh;
+      display: fex;
+      justify-content: center;
+    }
   `,
 
   Step: styled.p`
@@ -38,7 +47,6 @@ const S = {
 
   Title: styled.h1`
     font-family: 'EBSHunminjeongeum';
-    color: var(--gray900);
     font-weight: 900;
     font-size: 3.2rem;
   `,

--- a/src/pages/setup/components/SetNickname.tsx
+++ b/src/pages/setup/components/SetNickname.tsx
@@ -17,7 +17,7 @@ const SetNickname = ({ setNickname, setIsDisabled }: TSetNicknameProps) => {
     if (value === '') {
       setInvalidMsg('');
       setIsDisabled(true);
-    } else if (value.length > 7) {
+    } else if (value.length > 6) {
       setInvalidMsg('최대 6글자만 사용할 수 있습니다.');
       setIsDisabled(true);
     } else if (isCompleteKoreanWord(value)) {

--- a/src/pages/setup/components/SetPublicity.tsx
+++ b/src/pages/setup/components/SetPublicity.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 
+import { device } from '@styles/breakpoints';
 import styled from 'styled-components';
 import { PUBLICITY_SELECT } from '../constants/publicitySelect';
 import { TPublicity } from '../types/type';
@@ -56,35 +57,48 @@ export default SetPublicity;
 
 const S = {
   Container: styled.div`
-    margin: 40px 0 60px;
+    margin: 4rem 0 6rem;
   `,
 
   SelectorWrapper: styled.div`
     display: flex;
-    gap: 24px;
+    align-items: center;
+    justify-content: center;
+    gap: 2.4rem;
     cursor: pointer;
+    @media ${device.mobile} {
+      gap: 1.6rem;
+    }
   `,
 
   PublicitySelector: styled.div<{ $isSelected: boolean; $hasSelected: boolean }>`
     opacity: ${({ $isSelected, $hasSelected }) => ($hasSelected ? ($isSelected ? 1 : 0.4) : 1)};
-    padding: 33px 19px;
+    padding: 3.3rem 1.9rem;
     border: 1px solid var(--green600);
     border-radius: 2px;
-    width: 220px;
+    @media ${device.mobile} {
+      padding: 1.6rem 1.1rem 2.8rem;
+    }
 
     p {
       text-align: center;
       line-height: 150%;
-      color: var(--gray900);
       font-size: 1.8rem;
       font-weight: 900;
+      @media ${device.mobile} {
+        font-size: 1.6rem;
+      }
     }
   `,
 
   ImageWrapper: styled.div`
-    width: 180px;
-    height: 100px;
-    margin-bottom: 24px;
+    width: 18rem;
+    height: 10rem;
+    margin-bottom: 2.4rem;
+    @media ${device.mobile} {
+      width: 13rem;
+      height: 7.4rem;
+    }
   `,
 
   PublicityGuideText: styled.div`
@@ -93,13 +107,19 @@ const S = {
     p {
       &:first-child {
         font-size: 2.4rem;
-        font-weight: 400;
+        font-weight: 600;
         color: var(--green700);
         margin-bottom: 1.2rem;
+        @media ${device.mobile} {
+          font-size: 1.6rem;
+        }
       }
       &:last-child {
         font-size: 2rem;
         color: var(--gray700);
+        @media ${device.mobile} {
+          font-size: 1.3rem;
+        }
       }
     }
   `,

--- a/src/pages/setup/index.tsx
+++ b/src/pages/setup/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import PrimaryButton from '@components/PrimaryButton';
 import SettingTemplate from '@components/template/SettingTemplate';
+import { device } from '@styles/breakpoints';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import SetNickname from './components/SetNickname';
@@ -9,11 +10,10 @@ import { TPublicity } from './types/type';
 
 const SetUp = () => {
   const [step, setStep] = useState(1);
+  const [isDisabled, setIsDisabled] = useState(true);
   const [nickname, setNickname] = useState('');
   const [publicity, setPublicity] = useState<TPublicity>(null);
   const navigate = useNavigate();
-
-  const [isDisabled, setIsDisabled] = useState(true);
 
   const handleNextButtonClick = () => {
     setStep(step + 1);
@@ -40,7 +40,7 @@ const SetUp = () => {
           <SetPublicity setPublicity={setPublicity} publicity={publicity} />
           {publicity && <S.PublicityResetText>마이페이지에서 재설정이 가능합니다.</S.PublicityResetText>}
           <PrimaryButton disabled={isDisabled} onClick={handleSubmitButtonClick}>
-            나만의 책장 만들기
+            나의 책장 만들기
           </PrimaryButton>
         </SettingTemplate>
       )}
@@ -60,6 +60,7 @@ const S = {
   `,
 
   PublicityResetText: styled.p`
+    font-family: 'Pretendard';
     position: absolute;
     bottom: 6.4rem;
     margin-bottom: 1rem;
@@ -67,5 +68,8 @@ const S = {
     color: var(--gray600);
     width: 100%;
     text-align: center;
+    @media ${device.mobile} {
+      bottom: 8.6rem;
+    }
   `,
 };

--- a/src/styles/myReset.js
+++ b/src/styles/myReset.js
@@ -35,6 +35,7 @@ html {
   -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
   background-color: var(--background);
+  color: var(--gray900);
 }
 
 body {


### PR DESCRIPTION
## 🚀 작업 내용

- 초기 닉네임/공개여부 설정 페이지 반응형 적용(mobile)

## 📝 참고 사항

- 태블릿 반응형 디자인 시안이 없어서 일단 모바일로만 진행했습니다.

## 🖼️ 스크린샷
<img src="https://github.com/user-attachments/assets/703f9892-0032-472b-a40f-c8f663f742ad" width="300px"/>
<img src="https://github.com/user-attachments/assets/4e56dd15-0272-4d91-a132-2b4d75bdc9e8" width="300px"/>




## 🚨 관련 이슈

- #12 
