### PR TITLE
/ 페이지의 헤더 반응형 분기 추가

### DIFF
--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -5,6 +5,8 @@ import { device, size } from '@styles/breakpoints';
 import MainLogo from '@/assets/images/symbol-logo.png';
 import goBackIcon from '@assets/icons/left-arrow.svg';
 import Nav from './nav';
+import CloseIcon from '@components/icons/CloseIcon';
+import { HEADER_HEIGHT } from '@styles/headerHeight';
 
 const Header = () => {
   const [pageWidth, setPageWidth] = useState(window.innerWidth);
@@ -24,8 +26,11 @@ const Header = () => {
   }, []);
   return (
     <S.Container>
-      {pathname === '/setup' && pageWidth <= size.tablet ? (
-        <S.GoBackIcon src={goBackIcon} alt="뒤로 가기" />
+      {(pathname === '/setup' || pathname === '/') && pageWidth <= size.tablet ? (
+        <>
+          <S.GoBackIcon src={goBackIcon} alt="뒤로 가기" />
+          <CloseIcon width={19} height={19} color={'#626262'} />
+        </>
       ) : (
         <>
           <S.MainLogo src={MainLogo} alt="메인 로고" />
@@ -40,22 +45,22 @@ export default Header;
 const S = {
   Container: styled.header`
     width: 100%;
-    max-width: 102.4rem;
-    margin: 0 auto;
     grid-area: 'a';
     display: flex;
     justify-content: space-between;
     z-index: 20;
+    padding: 0 3.5rem;
+    background-color: var(--background);
 
     @media ${device.tablet} {
       align-items: center;
+      padding: 0 3rem;
     }
   `,
 
   MainLogo: styled.img`
     width: 16.2rem;
     object-fit: contain;
-    margin-left: 1rem;
 
     @media ${device.tablet} {
     }
@@ -64,7 +69,6 @@ const S = {
   GoBackIcon: styled.img`
     width: 1rem;
     height: 2rem;
-    margin-left: 2rem;
     cursor: pointer;
   `,
 };

--- a/src/components/icons/CloseIcon.tsx
+++ b/src/components/icons/CloseIcon.tsx
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+const CloseIcon = ({
+  width,
+  height,
+  color,
+  style,
+}: {
+  width: number;
+  height: number;
+  color: string;
+  style?: string;
+}) => {
+  return (
+    <S.Container
+      $style={style}
+      xmlns="http://www.w3.org/2000/svg"
+      width={width}
+      height={height}
+      viewBox="0 0 25 24"
+      fill="none">
+      <path d="M2.47656 0L0.00168888 2.39984L22.2756 23.9984L24.7504 21.5985L2.47656 0Z" fill={color} />
+      <path d="M0.00168888 2.39984L2.47656 0L24.7504 21.5985L22.2756 23.9984L0.00168888 2.39984Z" fill={color} />
+      <path d="M0 21.5986L2.47487 23.9985L24.7487 2.39994L22.2739 0.000106308L0 21.5986Z" fill={color} />
+      <path d="M2.47487 23.9985L0 21.5986L22.2739 0.000106308L24.7487 2.39994L2.47487 23.9985Z" fill={color} />
+    </S.Container>
+  );
+};
+
+export default CloseIcon;
+
+const S = {
+  Container: styled.svg<{ $style?: string }>`
+    ${({ $style }) => $style}
+  `,
+};


### PR DESCRIPTION
## 🚀 작업 내용
- / 페이지의 반응형이 깨지는 문제, 적절한 헤더를 렌더링하게 만들어 해결

## 📝 참고 사항
- 뒤로 가기 버튼의 역할이 이전 페이지로 이동하기도 하고, 이전 단계로 가기이기도 해서 어떻게 전달을 해줄 지 고민 중입니다.
- 닫기 버튼 역시..! 헤더의 X버튼에 모달이 닫히는 이벤트를 전달.....하려면 전역으로 모달의 열고 닫는 걸 관리를 해 줘야하나..? 싶기도 하고 여러모로 고민이라 여행 다녀와서 조금 더 고민해보겠습니다.

## 🖼️ 스크린샷
![수정](https://github.com/user-attachments/assets/b8ed9744-3bc8-43d9-911d-30231f809f42)



## 🚨 관련 이슈
- 
