### PR TITLE
`landing` 페이지 애니메이션 추가

### DIFF
--- a/src/pages/landing/components/BookshelfSection.tsx
+++ b/src/pages/landing/components/BookshelfSection.tsx
@@ -48,7 +48,7 @@ const S = {
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 0 2rem 3rem;
+    padding: 3rem 2rem 3rem;
     max-width: 35.6rem;
     margin: 0 auto;
     min-width: min-content;

--- a/src/pages/landing/components/LandingPC.tsx
+++ b/src/pages/landing/components/LandingPC.tsx
@@ -1,12 +1,8 @@
 import { MouseEvent, useState } from 'react';
-import treeImg from '@assets/images/tree.png';
-import typography from '@assets/images/typography-short.png';
 import styled from 'styled-components';
-import BookshelfCard from './BookshelfCard';
-import TotalCount from './BookshelfCard/components/TotalCount';
-import ButtonSection from './ButtonSection';
-import DescriptionSection from './DescriptionSection';
-import TitleSection from './TitleSection';
+import FirstSection from './LandingPC/components/FirstSection';
+import SecondSection from './LandingPC/components/SecondSection';
+import ThirdSection from './LandingPC/components/ThirdSection';
 
 import { TCardShelfData, TRandomCardSelf } from '../mockData';
 
@@ -23,92 +19,21 @@ const LandingPC = ({ randomCardData, kingData }: TBookShelf) => {
 
   return (
     <>
-      <S.Main $isFirst={page === 1} $treeImg={treeImg} $background={typography}>
-        <S.Layout $page={page}>
-          {page === 1 && (
-            <>
-              <TitleSection />
-              <DescriptionSection />
-            </>
-          )}
-          {page === 2 && (
-            <S.KingSeJongCard>
-              <S.BookCountLayout>
-                <TotalCount totalBookCount={kingData.totalBookCount} size={'large'} />
-              </S.BookCountLayout>
-              <S.DescriptionText className="hover-card">{kingData.description}</S.DescriptionText>
-              <S.CardHover className="hover-card" />
-              <S.KinSeJongImg src={kingData.imageUrl} alt={kingData.owner} />
-            </S.KingSeJongCard>
-          )}
-          {page === 3 && (
-            <>
-              <div>
-                <S.Title>누구나 오시오.</S.Title>
-                <S.SubTitle>공개된 책장이오. 매일 무작위로 공개되오.</S.SubTitle>
-              </div>
-              <S.RandomCardContainer>
-                {randomCardData.bookList.map(book => (
-                  <BookshelfCard cardData={book} />
-                ))}
-              </S.RandomCardContainer>
-            </>
-          )}
-          <ButtonSection page={page} />
-          <S.PageTransferContainer>
-            <S.PageTransferButton type="button" value={1} isShow={1 === page} onClick={handlePageTransfer} />
-            <S.PageTransferButton type="button" value={2} isShow={2 === page} onClick={handlePageTransfer} />
-            <S.PageTransferButton type="button" value={3} isShow={3 === page} onClick={handlePageTransfer} />
-          </S.PageTransferContainer>
-        </S.Layout>
-      </S.Main>
+      {page === 1 && <FirstSection page={page} />}
+      {page === 2 && <SecondSection page={page} kingData={kingData} />}
+      {page === 3 && <ThirdSection page={page} randomCardData={randomCardData.bookList} />}
+
+      <S.PageTransferContainer>
+        <S.PageTransferButton type="button" value={1} isShow={1 === page} onClick={handlePageTransfer} />
+        <S.PageTransferButton type="button" value={2} isShow={2 === page} onClick={handlePageTransfer} />
+        <S.PageTransferButton type="button" value={3} isShow={3 === page} onClick={handlePageTransfer} />
+      </S.PageTransferContainer>
     </>
   );
 };
 
 export default LandingPC;
 const S = {
-  Main: styled.div<{ $isFirst: boolean; $treeImg: string; $background: string }>`
-    height: 100dvh;
-    display: flex;
-    justify-content: center;
-    align-items: flex-end;
-    background: url(${typography}), linear-gradient(180deg, rgba(231, 221, 204, 0.75) 85%, #f6f3ee 100%);
-    background-size: contain;
-    background-position: left top;
-    &::before {
-      content: '';
-      min-width: 14.5rem;
-      min-height: 12.5rem;
-      background-image: url(${({ $treeImg }) => $treeImg});
-      background-size: cover;
-      position: absolute;
-      bottom: 6.4rem;
-      left: 0;
-      ${({ $isFirst }) =>
-        !$isFirst &&
-        `
-      display : none;`}
-    }
-  `,
-  Layout: styled.div<{ $page: number }>`
-    max-width: 86rem;
-    display: grid;
-    grid-template-columns: 1fr 31rem;
-    grid-column-gap: 11rem;
-    height: 100%;
-    max-height: 67rem;
-    padding-top: 14%;
-    margin-bottom: auto;
-    align-items: center;
-    ${({ $page }) =>
-      $page === 2 &&
-      `
-      grid-template-rows : 1fr;
-      padding-top : 10%;
-      align-items : center;
-    `};
-  `,
   PageTransferContainer: styled.div`
     position: absolute;
     left: 50%;
@@ -118,79 +43,11 @@ const S = {
     gap: 2rem;
     align-items: center;
   `,
-  RandomCardContainer: styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 1.6rem;
-    width: 44rem;
-    align-self: start;
-  `,
   PageTransferButton: styled.button<{ isShow: boolean }>`
     cursor: pointer;
     min-width: 1rem;
     min-height: 1rem;
     border: 0.1rem solid #c0aa87;
     ${({ isShow }) => isShow && 'background-color : #c0aa87'}
-  `,
-  KingSeJongCard: styled.div`
-    height: 50rem;
-    border-radius: 0.6rem;
-    overflow: hidden;
-    position: relative;
-
-    &:hover .hover-card {
-      opacity: 1;
-      transition: opacity 0.3s ease-in-out;
-    }
-  `,
-  CardHover: styled.div`
-    position: absolute;
-    width: 46.4rem;
-    height: 26rem;
-    bottom: 0;
-    z-index: 1;
-    opacity: 0;
-    background: linear-gradient(180deg, rgba(34, 34, 34, 0) 15.85%, rgba(34, 34, 34, 0.44) 37.17%, #222 100%);
-    mix-blend-mode: multiply;
-    transition: opacity 0.3s ease-in-out;
-  `,
-  KinSeJongImg: styled.img`
-    width: 100%;
-    height: 100%;
-  `,
-  DescriptionText: styled.p`
-    color: var(--white);
-    font-family: 'Pretendard';
-    font-size: 2.4rem;
-    font-weight: 500;
-    line-height: 150%;
-    position: absolute;
-    bottom: 4rem;
-    left: 4rem;
-    right: 4rem;
-    z-index: 2;
-    opacity: 0;
-    transition: opacity 0.3s ease-in-out;
-  `,
-  BookCountLayout: styled.div`
-    position: absolute;
-    right: 2rem;
-    top: 2rem;
-  `,
-
-  // Typography
-  Title: styled.h1`
-    color: var(--gray900);
-    font-family: 'EBSHMJESaeron';
-    font-size: 3.2rem;
-    line-height: 130%;
-  `,
-  SubTitle: styled.h2`
-    color: var(--gray7002);
-    font-family: 'Pretendard';
-    font-size: 2rem;
-    font-weight: 500;
-    line-height: 130%;
-    letter-spacing: -0.02rem;
   `,
 };

--- a/src/pages/landing/components/LandingPC.tsx
+++ b/src/pages/landing/components/LandingPC.tsx
@@ -18,24 +18,38 @@ const LandingPC = ({ randomCardData, kingData }: TBookShelf) => {
   };
 
   return (
-    <>
-      {page === 1 && <FirstSection page={page} />}
-      {page === 2 && <SecondSection page={page} kingData={kingData} />}
-      {page === 3 && <ThirdSection page={page} randomCardData={randomCardData.bookList} />}
-
+    <S.Container>
+      <S.SectionContainer $page={page}>
+        <FirstSection />
+        <SecondSection kingData={kingData} />
+        <ThirdSection randomCardData={randomCardData.bookList} />
+      </S.SectionContainer>
       <S.PageTransferContainer>
         <S.PageTransferButton type="button" value={1} isShow={1 === page} onClick={handlePageTransfer} />
         <S.PageTransferButton type="button" value={2} isShow={2 === page} onClick={handlePageTransfer} />
         <S.PageTransferButton type="button" value={3} isShow={3 === page} onClick={handlePageTransfer} />
       </S.PageTransferContainer>
-    </>
+    </S.Container>
   );
 };
 
 export default LandingPC;
 const S = {
+  Container: styled.div`
+    overflow-y: hidden;
+    overflow-x: scroll;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  `,
+  SectionContainer: styled.div<{ $page: number }>`
+    display: flex;
+    transform: translateX(calc(-100dvw * ${({ $page }) => $page - 1}));
+    transition: transform 0.5s ease-in-out;
+  `,
   PageTransferContainer: styled.div`
-    position: absolute;
+    position: fixed;
     left: 50%;
     transform: translateX(-50%);
     bottom: 1rem;

--- a/src/pages/landing/components/LandingPC/components/FirstSection.tsx
+++ b/src/pages/landing/components/LandingPC/components/FirstSection.tsx
@@ -1,0 +1,36 @@
+import treeImg from '@assets/images/tree.png';
+import styled from 'styled-components';
+import ButtonSection from '../../ButtonSection';
+import DescriptionSection from '../../DescriptionSection';
+import TitleSection from '../../TitleSection';
+import { Main as BaseMain, Layout } from '../style/commonPC';
+
+const FirstSection = ({ page }: { page: number }) => {
+  return (
+    <S.Main>
+      <S.Layout>
+        <TitleSection />
+        <DescriptionSection />
+        <ButtonSection page={page} />
+      </S.Layout>
+    </S.Main>
+  );
+};
+
+export default FirstSection;
+
+const S = {
+  Main: styled(BaseMain)`
+    &::before {
+      content: '';
+      min-width: 14.5rem;
+      min-height: 12.5rem;
+      background-image: url(${treeImg});
+      background-size: cover;
+      position: absolute;
+      bottom: 6.4rem;
+      left: 0;
+    }
+  `,
+  Layout,
+};

--- a/src/pages/landing/components/LandingPC/components/FirstSection.tsx
+++ b/src/pages/landing/components/LandingPC/components/FirstSection.tsx
@@ -5,13 +5,13 @@ import DescriptionSection from '../../DescriptionSection';
 import TitleSection from '../../TitleSection';
 import { Main as BaseMain, Layout } from '../style/commonPC';
 
-const FirstSection = ({ page }: { page: number }) => {
+const FirstSection = () => {
   return (
     <S.Main>
       <S.Layout>
         <TitleSection />
         <DescriptionSection />
-        <ButtonSection page={page} />
+        <ButtonSection page={1} />
       </S.Layout>
     </S.Main>
   );

--- a/src/pages/landing/components/LandingPC/components/SecondSection.tsx
+++ b/src/pages/landing/components/LandingPC/components/SecondSection.tsx
@@ -6,10 +6,9 @@ import { Main as BaseMain, Layout as BaseLayout } from '../style/commonPC';
 
 interface TSecondSection {
   kingData: TCardShelfData;
-  page: number;
 }
 
-const SecondSection = ({ kingData, page }: TSecondSection) => {
+const SecondSection = ({ kingData }: TSecondSection) => {
   return (
     <S.Main>
       <S.Layout>
@@ -21,7 +20,7 @@ const SecondSection = ({ kingData, page }: TSecondSection) => {
           <S.CardHover className="hover-card" />
           <S.KinSeJongImg src={kingData.imageUrl} alt={kingData.owner} />
         </S.KingSeJongCard>
-        <ButtonSection page={page} />
+        <ButtonSection page={2} />
       </S.Layout>
     </S.Main>
   );

--- a/src/pages/landing/components/LandingPC/components/SecondSection.tsx
+++ b/src/pages/landing/components/LandingPC/components/SecondSection.tsx
@@ -1,0 +1,84 @@
+import { TCardShelfData } from '@pages/landing/mockData';
+import styled from 'styled-components';
+import TotalCount from '../../BookshelfCard/components/TotalCount';
+import ButtonSection from '../../ButtonSection';
+import { Main as BaseMain, Layout as BaseLayout } from '../style/commonPC';
+
+interface TSecondSection {
+  kingData: TCardShelfData;
+  page: number;
+}
+
+const SecondSection = ({ kingData, page }: TSecondSection) => {
+  return (
+    <S.Main>
+      <S.Layout>
+        <S.KingSeJongCard>
+          <S.BookCountLayout>
+            <TotalCount totalBookCount={kingData.totalBookCount} size={'large'} />
+          </S.BookCountLayout>
+          <S.DescriptionText className="hover-card">{kingData.description}</S.DescriptionText>
+          <S.CardHover className="hover-card" />
+          <S.KinSeJongImg src={kingData.imageUrl} alt={kingData.owner} />
+        </S.KingSeJongCard>
+        <ButtonSection page={page} />
+      </S.Layout>
+    </S.Main>
+  );
+};
+
+export default SecondSection;
+
+const S = {
+  Main: styled(BaseMain)``,
+  Layout: styled(BaseLayout)`
+    grid-template-rows: 1fr;
+    padding-top: 10%;
+    align-items: center;
+  `,
+  KingSeJongCard: styled.div`
+    height: 50rem;
+    border-radius: 0.6rem;
+    overflow: hidden;
+    position: relative;
+
+    &:hover .hover-card {
+      opacity: 1;
+      transition: opacity 0.3s ease-in-out;
+    }
+  `,
+  CardHover: styled.div`
+    position: absolute;
+    width: 46.4rem;
+    height: 26rem;
+    bottom: 0;
+    z-index: 1;
+    opacity: 0;
+    background: linear-gradient(180deg, rgba(34, 34, 34, 0) 15.85%, rgba(34, 34, 34, 0.44) 37.17%, #222 100%);
+    mix-blend-mode: multiply;
+    transition: opacity 0.3s ease-in-out;
+  `,
+  KinSeJongImg: styled.img`
+    width: 100%;
+    height: 100%;
+  `,
+  DescriptionText: styled.p`
+    color: var(--white);
+    font-family: 'Pretendard';
+    font-size: 2.4rem;
+    font-weight: 500;
+    line-height: 150%;
+    position: absolute;
+    bottom: 4rem;
+    left: 4rem;
+    right: 4rem;
+    z-index: 2;
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
+  `,
+  BookCountLayout: styled.div`
+    position: absolute;
+    right: 2rem;
+    top: 2rem;
+  `,
+};

--- a/src/pages/landing/components/LandingPC/components/ThirdSection.tsx
+++ b/src/pages/landing/components/LandingPC/components/ThirdSection.tsx
@@ -1,0 +1,57 @@
+import { TCardShelfData } from '@pages/landing/mockData';
+import styled from 'styled-components';
+import BookshelfCard from '../../BookshelfCard';
+import ButtonSection from '../../ButtonSection';
+import { Main as BaseMain, Layout as BaseLayout } from '../style/commonPC';
+
+interface TThirdSection {
+  page: number;
+  randomCardData: TCardShelfData[];
+}
+
+const ThirdSection = ({ page, randomCardData }: TThirdSection) => {
+  return (
+    <S.Main>
+      <S.Layout>
+        <div>
+          <S.Title>누구나 오시오.</S.Title>
+          <S.SubTitle>공개된 책장이오. 매일 무작위로 공개되오.</S.SubTitle>
+        </div>
+        <S.RandomCardContainer>
+          {randomCardData.map(book => (
+            <BookshelfCard cardData={book} />
+          ))}
+        </S.RandomCardContainer>
+        <ButtonSection page={page} />
+      </S.Layout>
+    </S.Main>
+  );
+};
+
+export default ThirdSection;
+
+const S = {
+  Main: styled(BaseMain)``,
+  Layout: styled(BaseLayout)``,
+  RandomCardContainer: styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1.6rem;
+    width: 44rem;
+    align-self: start;
+  `,
+  Title: styled.h1`
+    color: var(--gray900);
+    font-family: 'EBSHMJESaeron';
+    font-size: 3.2rem;
+    line-height: 130%;
+  `,
+  SubTitle: styled.h2`
+    color: var(--gray7002);
+    font-family: 'Pretendard';
+    font-size: 2rem;
+    font-weight: 500;
+    line-height: 130%;
+    letter-spacing: -0.02rem;
+  `,
+};

--- a/src/pages/landing/components/LandingPC/components/ThirdSection.tsx
+++ b/src/pages/landing/components/LandingPC/components/ThirdSection.tsx
@@ -5,11 +5,10 @@ import ButtonSection from '../../ButtonSection';
 import { Main as BaseMain, Layout as BaseLayout } from '../style/commonPC';
 
 interface TThirdSection {
-  page: number;
   randomCardData: TCardShelfData[];
 }
 
-const ThirdSection = ({ page, randomCardData }: TThirdSection) => {
+const ThirdSection = ({ randomCardData }: TThirdSection) => {
   return (
     <S.Main>
       <S.Layout>
@@ -22,7 +21,7 @@ const ThirdSection = ({ page, randomCardData }: TThirdSection) => {
             <BookshelfCard cardData={book} />
           ))}
         </S.RandomCardContainer>
-        <ButtonSection page={page} />
+        <ButtonSection page={3} />
       </S.Layout>
     </S.Main>
   );

--- a/src/pages/landing/components/LandingPC/components/ThirdSection.tsx
+++ b/src/pages/landing/components/LandingPC/components/ThirdSection.tsx
@@ -1,4 +1,6 @@
+import { MouseEvent } from 'react';
 import { TCardShelfData } from '@pages/landing/mockData';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import BookshelfCard from '../../BookshelfCard';
 import ButtonSection from '../../ButtonSection';
@@ -9,6 +11,10 @@ interface TThirdSection {
 }
 
 const ThirdSection = ({ randomCardData }: TThirdSection) => {
+  const navigate = useNavigate();
+  const redirectBookshelf = (event: MouseEvent<HTMLButtonElement>) => {
+    navigate(`/bookshelf/${event.currentTarget.id}`);
+  };
   return (
     <S.Main>
       <S.Layout>
@@ -18,7 +24,9 @@ const ThirdSection = ({ randomCardData }: TThirdSection) => {
         </div>
         <S.RandomCardContainer>
           {randomCardData.map(book => (
-            <BookshelfCard cardData={book} />
+            <button type="button" id={String(book.id)} onClick={redirectBookshelf} style={{ cursor: 'pointer' }}>
+              <BookshelfCard cardData={book} key={book.id} />
+            </button>
           ))}
         </S.RandomCardContainer>
         <ButtonSection page={3} />

--- a/src/pages/landing/components/LandingPC/style/commonPC.ts
+++ b/src/pages/landing/components/LandingPC/style/commonPC.ts
@@ -1,0 +1,24 @@
+import typography from '@assets/images/typography-short.png';
+import styled from 'styled-components';
+
+export const Main = styled.div`
+  height: 100dvh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  background: url(${typography}), linear-gradient(180deg, rgba(231, 221, 204, 0.75) 85%, #f6f3ee 100%);
+  background-size: contain;
+  background-position: left top;
+`;
+
+export const Layout = styled.div`
+  max-width: 86rem;
+  display: grid;
+  grid-template-columns: 1fr 31rem;
+  grid-column-gap: 11rem;
+  height: 100%;
+  max-height: 67rem;
+  padding-top: 14%;
+  margin-bottom: auto;
+  align-items: center;
+`;

--- a/src/pages/landing/components/LandingPC/style/commonPC.ts
+++ b/src/pages/landing/components/LandingPC/style/commonPC.ts
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 
 export const Main = styled.div`
   height: 100dvh;
+  min-width: 100dvw;
   display: flex;
   justify-content: center;
   align-items: flex-end;

--- a/src/pages/landing/index.tsx
+++ b/src/pages/landing/index.tsx
@@ -81,6 +81,7 @@ const S = {
     color: #fff;
     text-align: center;
     cursor: pointer;
+    flex-shrink: 0;
 
     @media ${device.tablet} {
       max-width: 43rem;


### PR DESCRIPTION
## 🚀 작업 내용
- PC 랜딩 페이지별 파일 분리 후 translate로 애니메이션 주었습니다.

## 📝 참고 사항
- 모바일에서 레이아웃이 깨지는 문제 수정해두었습니다

## 🖼️ 스크린샷
![랜딩 애니메이션](https://github.com/user-attachments/assets/c3779207-55fd-44a6-9371-e0ef209b7070)



## 🚨 관련 이슈

- 
