### PR TITLE
`/myPage` 책장 소개글 변경, 공개 여부 변경 기능 구현 

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <div id="portal"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/components/PrimaryInput/index.tsx
+++ b/src/components/PrimaryInput/index.tsx
@@ -5,10 +5,11 @@ interface TPrimaryInputProps {
   placeholder: string;
   onChange: (value: string) => void;
   invalidMsg: string;
+  value?: string;
 }
 
 const PrimaryInput = (props: TPrimaryInputProps) => {
-  const { placeholder, onChange, invalidMsg } = props;
+  const { placeholder, onChange, invalidMsg, value } = props;
 
   const onInput = (e: React.FormEvent<HTMLInputElement>) => {
     const inputValue = e.currentTarget.value;
@@ -23,7 +24,13 @@ const PrimaryInput = (props: TPrimaryInputProps) => {
 
   return (
     <S.Container>
-      <S.Input $isInvalid={!!invalidMsg} placeholder={placeholder} onInput={onInput} onKeyDown={handleKeyDown} />
+      <S.Input
+        $isInvalid={!!invalidMsg}
+        placeholder={placeholder}
+        onInput={onInput}
+        onKeyDown={handleKeyDown}
+        value={value}
+      />
       {invalidMsg && <S.InvalidMsg>{invalidMsg}</S.InvalidMsg>}
     </S.Container>
   );

--- a/src/components/template/ModalBaseTemplate/ModalBaseTemplate.tsx
+++ b/src/components/template/ModalBaseTemplate/ModalBaseTemplate.tsx
@@ -1,0 +1,70 @@
+import { ReactNode, useRef } from 'react';
+import closeIcon from '@assets/icons/modal-close.svg';
+import useOutsideClick from '@hooks/useOutsideClick';
+import { device } from '@styles/breakpoints';
+import { zIndex } from '@styles/zIndex';
+import styled from 'styled-components';
+import Portal from '../Portal';
+
+interface TModalBaseTemplate {
+  children: ReactNode;
+  handleCloseModal: () => void;
+}
+
+const ModalBaseTemplate = ({ children, handleCloseModal }: TModalBaseTemplate) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+  useOutsideClick(modalRef, handleCloseModal);
+
+  return (
+    <Portal>
+      <S.ModalBox ref={modalRef}>
+        <S.ModalCloseButton type="button" onClick={handleCloseModal}>
+          <img src={closeIcon} alt="모달 닫기" />
+        </S.ModalCloseButton>
+        {children}
+      </S.ModalBox>
+      <S.DimContainer />
+    </Portal>
+  );
+};
+
+export default ModalBaseTemplate;
+
+const S = {
+  DimContainer: styled.div`
+    position: fixed;
+    background-color: rgba(0, 0, 0, 0.6);
+    inset: 0;
+    z-index: ${zIndex.modal};
+  `,
+  ModalBox: styled.div`
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: ${zIndex.modal + 1};
+    background-color: var(--background);
+    padding: 7rem 6.2rem 6rem;
+    border-radius: 1rem;
+    width: 46.4rem;
+
+    @media ${device.mobile} {
+      bottom: 0;
+      left: 0;
+      right: 0;
+      transform: none;
+      width: 100%;
+      padding: 6rem 2rem 4rem;
+
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    }
+  `,
+  ModalCloseButton: styled.button`
+    cursor: pointer;
+    position: absolute;
+    right: 1.5rem;
+    top: 1.5rem;
+  `,
+};

--- a/src/components/template/ModalBaseTemplate/style/commonModalStyle.ts
+++ b/src/components/template/ModalBaseTemplate/style/commonModalStyle.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const ModalTitle = styled.h1`
+  color: var(--gray900);
+  text-align: center;
+  font-family: 'EBSHMJESaeron';
+  font-size: 2.8rem;
+  font-weight: 700;
+`;

--- a/src/components/template/Portal.tsx
+++ b/src/components/template/Portal.tsx
@@ -1,0 +1,14 @@
+import { PropsWithChildren } from 'react';
+import ReactDOM from 'react-dom';
+
+const Portal = ({ children }: PropsWithChildren) => {
+  const portalElement = document.getElementById('portal');
+
+  if (!portalElement) {
+    throw new Error("ID가 'portal'인 포털 엘리먼트를 찾을 수 없습니다.");
+  }
+
+  return ReactDOM.createPortal(<>{children}</>, portalElement);
+};
+
+export default Portal;

--- a/src/pages/myPage/components/editSection/hooks/useScopeValue.ts
+++ b/src/pages/myPage/components/editSection/hooks/useScopeValue.ts
@@ -4,8 +4,16 @@ const useScopeValue = () => {
   const [isEnterScope, setIsEnterScope] = useState(true);
 
   const handleSetScope = (event: MouseEvent<HTMLButtonElement>, apiCallback: (newScopeValue: boolean) => void) => {
+    const scope = event.currentTarget.dataset.scope;
+
+    if (!scope) {
+      console.error('scope가 없어옹 ㅠㅅㅠ');
+      return;
+    }
+
+    const newScopeValue = Boolean(+scope);
+
     setIsEnterScope(prevScopeValue => {
-      const newScopeValue = Boolean(+event.currentTarget.value);
       apiCallback(newScopeValue);
       return newScopeValue;
     });

--- a/src/pages/myPage/components/editSection/index.tsx
+++ b/src/pages/myPage/components/editSection/index.tsx
@@ -81,7 +81,7 @@ const EditSection = ({ bookshelfData }: TEditSection) => {
           방명록 주인을 포함한 모두가 볼수있어요!
         </S.Description>
       </S.SettingOne>
-      <S.SettingOne>
+      <S.SettingOne style={{ marginTop: '-3rem' }}>
         <S.SettingLayout>
           <S.SettingTitle>낮과 밤</S.SettingTitle>
           <button type="button">토글 버튼</button>

--- a/src/pages/myPage/components/editSection/index.tsx
+++ b/src/pages/myPage/components/editSection/index.tsx
@@ -17,11 +17,7 @@ const EditSection = ({ bookshelfData }: TEditSection) => {
   const { introduction, backgroundImageUrl, nickname, open } = bookshelfData;
   const { value, handleChangeValue, handleSetValue } = useInputValue();
   const { isEnterScope, handleSetScope, handleInitialSetScope } = useScopeValue();
-  const patchIntroduction = useBookshelfPublicityUpdateMutation();
-
-  const handleSetScopeValue = (event: MouseEvent<HTMLButtonElement>) => {
-    handleSetScope(event, patchIntroduction.mutate);
-  };
+  const patchOpenScope = useBookshelfPublicityUpdateMutation();
 
   useEffect(() => {
     handleSetValue(introduction ? introduction : '');
@@ -29,6 +25,11 @@ const EditSection = ({ bookshelfData }: TEditSection) => {
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const handleSetScopeValue = (event: MouseEvent<HTMLButtonElement>) => {
+    handleSetScope(event, patchOpenScope.mutate);
+  };
+
   return (
     <S.Container>
       <S.ImageIntroduction>
@@ -59,10 +60,10 @@ const EditSection = ({ bookshelfData }: TEditSection) => {
         <S.OpenOption>
           <S.SettingTitle>공개여부</S.SettingTitle>
           <S.OpenOptionContainer>
-            <S.OpenButton $isSelect={isEnterScope === true} type="button" value={1} onClick={handleSetScopeValue}>
+            <S.OpenButton $isSelect={isEnterScope === true} type="button" data-scope="1" onClick={handleSetScopeValue}>
               모두 보길 원하오
             </S.OpenButton>
-            <S.OpenButton $isSelect={isEnterScope === false} type="button" value={0} onClick={handleSetScopeValue}>
+            <S.OpenButton $isSelect={isEnterScope === false} type="button" data-scope="0" onClick={handleSetScopeValue}>
               주인장만 보길 원하오
             </S.OpenButton>
           </S.OpenOptionContainer>

--- a/src/pages/myPage/components/renameModal/index.tsx
+++ b/src/pages/myPage/components/renameModal/index.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from 'react';
+import closeIcon from '@assets/icons/modal-close.svg';
+import PrimaryButton from '@components/PrimaryButton';
+import PrimaryInput from '@components/PrimaryInput';
+import useInputValue from '@hooks/useInputText';
+import useOutsideClick from '@hooks/useOutsideClick';
+import { zIndex } from '@styles/zIndex';
+import styled from 'styled-components';
+
+interface TRenameModal {
+  handleCloseModal: () => void;
+  beforeNickName: string | null;
+}
+
+const RenameModal = (props: TRenameModal) => {
+  const { handleCloseModal, beforeNickName } = props;
+  const { value: nickNameValue, handleSetValue } = useInputValue();
+  const modalRef = useRef<HTMLDivElement>(null);
+  useOutsideClick(modalRef, handleCloseModal);
+
+  useEffect(() => {
+    if (beforeNickName) {
+      handleSetValue(beforeNickName);
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      <S.ModalBox ref={modalRef}>
+        <S.ModalCloseButton type="button" onClick={handleCloseModal}>
+          <S.ModalClose src={closeIcon} alt="모달 닫기" />
+        </S.ModalCloseButton>
+        <div style={{ marginTop: '1.6rem' }}>
+          <S.ModalTitle>이름 변경 모달~!</S.ModalTitle>
+        </div>
+        <PrimaryInput
+          placeholder="새로운 이름을 입력해주세요."
+          onChange={handleSetValue}
+          invalidMsg=""
+          value={nickNameValue}
+        />
+        <div style={{ marginTop: '4rem' }}>
+          <PrimaryButton>변경하기</PrimaryButton>
+        </div>
+      </S.ModalBox>
+      <S.DimContainer />
+    </>
+  );
+};
+
+export default RenameModal;
+
+const S = {
+  DimContainer: styled.div`
+    position: fixed;
+    background-color: rgba(0, 0, 0, 0.6);
+    inset: 0;
+    z-index: ${zIndex.modal};
+  `,
+  ModalBox: styled.div`
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: ${zIndex.modal + 1};
+    background-color: var(--background);
+    padding: 7rem 6.2rem 6rem;
+    border-radius: 1rem;
+    width: 48rem;
+  `,
+
+  // Typography
+  ModalTitle: styled.h1`
+    color: var(--gray900);
+    text-align: center;
+    font-family: 'EBSHMJESaeron';
+    font-size: 2.8rem;
+  `,
+
+  // icon
+  ModalClose: styled.img``,
+
+  // button
+  ModalCloseButton: styled.button`
+    cursor: pointer;
+    position: absolute;
+    right: 1.5rem;
+    top: 1.5rem;
+  `,
+};

--- a/src/pages/myPage/components/renameModal/index.tsx
+++ b/src/pages/myPage/components/renameModal/index.tsx
@@ -4,6 +4,7 @@ import PrimaryButton from '@components/PrimaryButton';
 import PrimaryInput from '@components/PrimaryInput';
 import useInputValue from '@hooks/useInputText';
 import useOutsideClick from '@hooks/useOutsideClick';
+import { device } from '@styles/breakpoints';
 import { zIndex } from '@styles/zIndex';
 import styled from 'styled-components';
 
@@ -33,7 +34,7 @@ const RenameModal = (props: TRenameModal) => {
           <S.ModalClose src={closeIcon} alt="모달 닫기" />
         </S.ModalCloseButton>
         <div style={{ marginTop: '1.6rem' }}>
-          <S.ModalTitle>이름 변경 모달~!</S.ModalTitle>
+          <S.ModalTitle>이름을 바꾸겠소?</S.ModalTitle>
         </div>
         <PrimaryInput
           placeholder="새로운 이름을 입력해주세요."
@@ -69,6 +70,19 @@ const S = {
     padding: 7rem 6.2rem 6rem;
     border-radius: 1rem;
     width: 48rem;
+
+    @media ${device.mobile} {
+      bottom: 0;
+      left: 0;
+      right: 0;
+      transform: none;
+      width: 100%;
+      padding: 6rem 2rem 4rem;
+
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    }
   `,
 
   // Typography
@@ -77,6 +91,7 @@ const S = {
     text-align: center;
     font-family: 'EBSHMJESaeron';
     font-size: 2.8rem;
+    font-weight: 700;
   `,
 
   // icon

--- a/src/pages/myPage/components/renameModal/index.tsx
+++ b/src/pages/myPage/components/renameModal/index.tsx
@@ -1,12 +1,10 @@
-import { useEffect, useRef } from 'react';
-import closeIcon from '@assets/icons/modal-close.svg';
+import { useEffect } from 'react';
 import PrimaryButton from '@components/PrimaryButton';
 import PrimaryInput from '@components/PrimaryInput';
+import ModalBaseTemplate from '@components/template/ModalBaseTemplate/ModalBaseTemplate';
+import { ModalTitle } from '@components/template/ModalBaseTemplate/style/commonModalStyle';
+import Portal from '@components/template/Portal';
 import useInputValue from '@hooks/useInputText';
-import useOutsideClick from '@hooks/useOutsideClick';
-import { device } from '@styles/breakpoints';
-import { zIndex } from '@styles/zIndex';
-import styled from 'styled-components';
 
 interface TRenameModal {
   handleCloseModal: () => void;
@@ -16,8 +14,6 @@ interface TRenameModal {
 const RenameModal = (props: TRenameModal) => {
   const { handleCloseModal, beforeNickName } = props;
   const { value: nickNameValue, handleSetValue } = useInputValue();
-  const modalRef = useRef<HTMLDivElement>(null);
-  useOutsideClick(modalRef, handleCloseModal);
 
   useEffect(() => {
     if (beforeNickName) {
@@ -28,11 +24,8 @@ const RenameModal = (props: TRenameModal) => {
   }, []);
 
   return (
-    <>
-      <S.ModalBox ref={modalRef}>
-        <S.ModalCloseButton type="button" onClick={handleCloseModal}>
-          <S.ModalClose src={closeIcon} alt="모달 닫기" />
-        </S.ModalCloseButton>
+    <Portal>
+      <ModalBaseTemplate handleCloseModal={handleCloseModal}>
         <div style={{ marginTop: '1.6rem' }}>
           <S.ModalTitle>이름을 바꾸겠소?</S.ModalTitle>
         </div>
@@ -45,63 +38,13 @@ const RenameModal = (props: TRenameModal) => {
         <div style={{ marginTop: '4rem' }}>
           <PrimaryButton>변경하기</PrimaryButton>
         </div>
-      </S.ModalBox>
-      <S.DimContainer />
-    </>
+      </ModalBaseTemplate>
+    </Portal>
   );
 };
 
 export default RenameModal;
 
 const S = {
-  DimContainer: styled.div`
-    position: fixed;
-    background-color: rgba(0, 0, 0, 0.6);
-    inset: 0;
-    z-index: ${zIndex.modal};
-  `,
-  ModalBox: styled.div`
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    z-index: ${zIndex.modal + 1};
-    background-color: var(--background);
-    padding: 7rem 6.2rem 6rem;
-    border-radius: 1rem;
-    width: 48rem;
-
-    @media ${device.mobile} {
-      bottom: 0;
-      left: 0;
-      right: 0;
-      transform: none;
-      width: 100%;
-      padding: 6rem 2rem 4rem;
-
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between;
-    }
-  `,
-
-  // Typography
-  ModalTitle: styled.h1`
-    color: var(--gray900);
-    text-align: center;
-    font-family: 'EBSHMJESaeron';
-    font-size: 2.8rem;
-    font-weight: 700;
-  `,
-
-  // icon
-  ModalClose: styled.img``,
-
-  // button
-  ModalCloseButton: styled.button`
-    cursor: pointer;
-    position: absolute;
-    right: 1.5rem;
-    top: 1.5rem;
-  `,
+  ModalTitle,
 };

--- a/src/pages/myPage/index.tsx
+++ b/src/pages/myPage/index.tsx
@@ -3,6 +3,7 @@ import leftArrowIcon from '@assets/icons/left-arrow-tail.svg';
 import rewriteIcon from '@assets/icons/rewrite.svg';
 import { useBookshelfQuery } from '@hooks/reactQuery/useQueryBookshelf';
 import { useUserQuery } from '@hooks/reactQuery/useQueryUser';
+import useToggle from '@hooks/useToggle';
 import { device } from '@styles/breakpoints';
 import { HEADER_HEIGHT } from '@styles/headerHeight';
 import { getCookie } from '@utils/cookie';
@@ -10,6 +11,7 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import BookListSection from './components/bookListSection';
 import EditSection from './components/editSection';
+import RenameModal from './components/renameModal';
 import SettingListSection from './components/settingListSection';
 import { useSettingType } from './hooks/useSettingType';
 import { mockData } from './mockData';
@@ -18,6 +20,7 @@ const MyPage = () => {
   const { settingType, handleSetType, handleSetDefault } = useSettingType();
   const { data: userInfo } = useUserQuery();
   const { data: myBookShelf } = useBookshelfQuery(userInfo?.id);
+  const { isTrue: isOpen, handleSetTrue: handleOpenModal, handleSetFalse: handleCloseModal } = useToggle();
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -29,48 +32,52 @@ const MyPage = () => {
   }, [navigate]);
 
   return (
-    <S.PageContainer>
-      <S.Container>
-        <S.ProfileSection>
-          {userInfo && (
-            <div>
-              <S.TitleText>
-                <span style={{ color: 'var(--green600)' }}>{userInfo.nickname}</span>님,
-              </S.TitleText>
-              {settingType === 'default' || settingType === 'edit' ? (
-                <S.TitleText>안녕하시오.</S.TitleText>
-              ) : (
-                <>
-                  <S.TitleText>
-                    책장을 이만큼 <br /> {settingType === 'receive' ? '받았다오.' : '보냈다오.'}
-                  </S.TitleText>
-                  <S.SubText>
-                    총 <span style={{ color: 'var(--red500)', textDecoration: 'underline' }}>{mockData.count}</span>개를
-                    {settingType === 'receive' ? '받았소.' : '보냈소.'}
-                  </S.SubText>
-                </>
-              )}
-              {(settingType === 'default' || settingType === 'edit') && (
-                <S.RenameButton type="button">
-                  <img src={rewriteIcon} alt={'닉네임 변경하기'} />
-                </S.RenameButton>
-              )}
-            </div>
-          )}
-          {settingType !== 'default' && (
-            <S.GoBackButton type="button" onClick={handleSetDefault}>
-              <S.GoBackIcon src={leftArrowIcon} alt="뒤로 가기" /> 뒤로 가기
-            </S.GoBackButton>
-          )}
-        </S.ProfileSection>
-        <S.SettingSection>
-          {settingType === 'default' && <SettingListSection handleSetType={handleSetType} />}
-          {settingType === 'receive' && <BookListSection bookList={mockData.list} settingType={'receive'} />}
-          {settingType === 'present' && <BookListSection bookList={mockData.list} settingType={'present'} />}
-          {settingType === 'edit' && myBookShelf && <EditSection bookshelfData={myBookShelf} />}
-        </S.SettingSection>
-      </S.Container>
-    </S.PageContainer>
+    <>
+      {isOpen && userInfo && <RenameModal handleCloseModal={handleCloseModal} beforeNickName={userInfo.nickname} />}
+      <S.PageContainer>
+        <S.Container>
+          <S.ProfileSection>
+            {userInfo && (
+              <div>
+                <S.TitleText>
+                  <span style={{ color: 'var(--green600)' }}>{userInfo.nickname}</span>님,
+                </S.TitleText>
+                {settingType === 'default' || settingType === 'edit' ? (
+                  <S.TitleText>안녕하시오.</S.TitleText>
+                ) : (
+                  <>
+                    <S.TitleText>
+                      책장을 이만큼 <br /> {settingType === 'receive' ? '받았다오.' : '보냈다오.'}
+                    </S.TitleText>
+                    <S.SubText>
+                      총 <span style={{ color: 'var(--red500)', textDecoration: 'underline' }}>{mockData.count}</span>
+                      개를
+                      {settingType === 'receive' ? '받았소.' : '보냈소.'}
+                    </S.SubText>
+                  </>
+                )}
+                {(settingType === 'default' || settingType === 'edit') && (
+                  <S.RenameButton type="button" onClick={handleOpenModal}>
+                    <img src={rewriteIcon} alt={'닉네임 변경하기'} />
+                  </S.RenameButton>
+                )}
+              </div>
+            )}
+            {settingType !== 'default' && (
+              <S.GoBackButton type="button" onClick={handleSetDefault}>
+                <S.GoBackIcon src={leftArrowIcon} alt="뒤로 가기" /> 뒤로 가기
+              </S.GoBackButton>
+            )}
+          </S.ProfileSection>
+          <S.SettingSection>
+            {settingType === 'default' && <SettingListSection handleSetType={handleSetType} />}
+            {settingType === 'receive' && <BookListSection bookList={mockData.list} settingType={'receive'} />}
+            {settingType === 'present' && <BookListSection bookList={mockData.list} settingType={'present'} />}
+            {settingType === 'edit' && myBookShelf && <EditSection bookshelfData={myBookShelf} />}
+          </S.SettingSection>
+        </S.Container>
+      </S.PageContainer>
+    </>
   );
 };
 


### PR DESCRIPTION
## 🚀 작업 내용
- 책장 소개글 변경, 공개 여부 변경은 api까지 연결 완료했습니다.
- 닉네임 변경은 모달 UI까지 구현했고, api 연결은 유효성 검사 로직 공용으로 사용할 수 있을 때 그때 로직 추가 후 api연결 하겠습니다. (지금해도 되긴 함)

## 📝 참고 사항
- PrimaryInput에 value prop을 옵셔널로 추가해서 사용했습니다.
-> 처음 로드 시 기존 회원은 기존 회원의 닉네임을 넣어줘야하기 때문에

## 🖼️ 스크린샷
![이름 수정 모달](https://github.com/user-attachments/assets/b98e38bc-379b-47e7-b8f3-4d99c911c78b)



## 🚨 관련 이슈
- 