### PR TITLE
`/book/:id` 보낸, 받은 방명록 상세보기 페이지

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -13,6 +13,7 @@ const Router = () => {
           <Route path="auth" element={<Page.Auth />} />
           <Route path="myPage" element={<Page.MyPage />} />
           <Route path="*" element={<Page.NotFound />} />
+          <Route path="/book/:id" element={<Page.ReadBook />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/api/book/bookRequest.ts
+++ b/src/api/book/bookRequest.ts
@@ -83,6 +83,16 @@ const bookRequest = {
       return error;
     }
   },
+
+  // 방명록 상세보기
+  fetchBookContent: async (bookId: number) => {
+    try {
+      const { data } = await axios.get(`member/book/get/${bookId}`);
+      return data;
+    } catch (error) {
+      return error;
+    }
+  },
 } as const;
 
 export default bookRequest;

--- a/src/api/book/bookRequest.type.ts
+++ b/src/api/book/bookRequest.type.ts
@@ -21,3 +21,12 @@ export interface TUserSendBookListRes {
   nickname: string;
   backgroundImageUrl: string;
 }
+
+export interface TBookDetailRes {
+  bookImageUrl: string;
+  createdAt: string;
+  description: string;
+  lock: boolean;
+  receiverNickname: string;
+  senderNickname: string;
+}

--- a/src/constants/queryKey.ts
+++ b/src/constants/queryKey.ts
@@ -5,4 +5,5 @@ export const QUERY_KEY = {
   bookInfo: 'bookInfo',
   receiveBook: 'receiveBook',
   sendBook: 'sendBook',
+  bookDetail: 'bookDetail',
 } as const;

--- a/src/hooks/reactQuery/useQueryBook.ts
+++ b/src/hooks/reactQuery/useQueryBook.ts
@@ -1,6 +1,6 @@
 import { TAxiosError } from '@api/axios';
 import bookRequest, { TReceiveSendBookListParams } from '@api/book/bookRequest';
-import { TBookItem, TUseReceiveBookListRes, TUserSendBookListRes } from '@api/book/bookRequest.type';
+import { TBookDetailRes, TBookItem, TUseReceiveBookListRes, TUserSendBookListRes } from '@api/book/bookRequest.type';
 import { QUERY_KEY } from '@constants/queryKey';
 import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getCookie } from '@utils/cookie';
@@ -112,5 +112,17 @@ export const useReceiveSendInfinity = (props: TReceiveSendBookList) => {
     },
   });
 
+  return query;
+};
+
+// 방명록 상세 보기
+export const useBookDetail = (bookId: number) => {
+  const accessToken = getCookie('accessToken');
+  if (!accessToken) throw new Error('No access token');
+
+  const query = useQuery<TBookDetailRes, Error>({
+    queryKey: [QUERY_KEY.bookDetail],
+    queryFn: async () => bookRequest.fetchBookContent(bookId),
+  });
   return query;
 };

--- a/src/pages/ReadBook/index.tsx
+++ b/src/pages/ReadBook/index.tsx
@@ -1,4 +1,6 @@
+import BookScollPaper from '@pages/main/components/bookshelf/BookScollPaper';
 import GoBackButton from '@pages/myPage/components/profileSection/components/GoBackButton';
+import { skeletonAnimation } from '@styles/animation/skeletonAnimation';
 import { device } from '@styles/breakpoints';
 import { HEADER_HEIGHT } from '@styles/headerHeight';
 import { useNavigate } from 'react-router-dom';
@@ -11,15 +13,26 @@ const ReadBook = () => {
     <S.Container>
       <S.ContentBox>
         <S.BookShelf />
-        <S.Book />
-        <S.GoBackButtonLayout>
+        <S.Book>
+          <BookScollPaper
+            ownerName={'여섯글자유저'}
+            content={
+              '아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구'
+            }
+            sender={'신나는토끼'}
+            isPreview={false}
+          />
+        </S.Book>
+      </S.ContentBox>
+      <S.GoBackButtonLayout>
+        <S.ButtonBox>
           <GoBackButton
             onClick={() => {
               navigate('/myPage');
             }}
           />
-        </S.GoBackButtonLayout>
-      </S.ContentBox>
+        </S.ButtonBox>
+      </S.GoBackButtonLayout>
     </S.Container>
   );
 };
@@ -31,14 +44,14 @@ const S = {
     width: 100vw;
     margin-top: ${HEADER_HEIGHT.PC};
     height: max-content;
-
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
-    background-color: black;
+    padding-bottom: 5rem;
 
     @media ${device.tablet} {
-      padding: 12.7rem 4rem;
+      padding: 5rem 4rem 10rem;
     }
 
     @media ${device.mobile} {
@@ -54,45 +67,48 @@ const S = {
     align-items: center;
     gap: 10rem;
     position: relative;
-    background-color: green;
+    padding: 8rem 0;
 
     @media ${device.tablet} {
       flex-direction: column;
       max-height: none;
       max-width: none;
-      justify-content: center;
-    }
-  `,
-  BookShelf: styled.div`
-    background-color: orange;
-    min-width: 20.9rem;
-    min-height: 44rem;
-    width: 20.9rem;
-    height: 44rem;
-  `,
-  Book: styled.div`
-    min-width: 50rem;
-    min-height: 54rem;
-    width: 48.5rem;
-    height: 54rem;
-    background-color: yellow;
-
-    @media ${device.tablet} {
-      min-width: 43rem;
-      min-height: 46.5rem;
-      width: 43rem;
-      height: 46.5rem;
+      justify-content: flex-start;
+      padding: 0;
     }
 
     @media ${device.mobile} {
-      min-width: 30rem;
+      height: 100%;
+    }
+  `,
+  BookShelf: styled.img`
+    min-width: 20.9rem;
+    min-height: 44rem;
+    width: 20.9rem;
+    ${skeletonAnimation}
+  `,
+  Book: styled.div`
+    position: static;
+    min-width: 48.5rem;
+    max-width: 48.5rem;
+
+    @media ${device.tablet} {
+      min-width: 41.2rem;
+    }
+
+    @media ${device.mobile} {
+      margin-right: 10rem;
+      width: 34rem;
+      min-width: 34rem;
       min-height: 45.5rem;
-      width: 30rem;
       height: 45.5rem;
     }
   `,
   GoBackButtonLayout: styled.div`
-    position: absolute;
-    bottom: -5rem;
+    max-width: 93rem;
+    width: 100%;
+  `,
+  ButtonBox: styled.div`
+    margin-right: auto;
   `,
 };

--- a/src/pages/ReadBook/index.tsx
+++ b/src/pages/ReadBook/index.tsx
@@ -1,0 +1,98 @@
+import GoBackButton from '@pages/myPage/components/profileSection/components/GoBackButton';
+import { device } from '@styles/breakpoints';
+import { HEADER_HEIGHT } from '@styles/headerHeight';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+const ReadBook = () => {
+  const navigate = useNavigate();
+
+  return (
+    <S.Container>
+      <S.ContentBox>
+        <S.BookShelf />
+        <S.Book />
+        <S.GoBackButtonLayout>
+          <GoBackButton
+            onClick={() => {
+              navigate('/myPage');
+            }}
+          />
+        </S.GoBackButtonLayout>
+      </S.ContentBox>
+    </S.Container>
+  );
+};
+
+export default ReadBook;
+
+const S = {
+  Container: styled.div`
+    width: 100vw;
+    margin-top: ${HEADER_HEIGHT.PC};
+    height: max-content;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: black;
+
+    @media ${device.tablet} {
+      padding: 12.7rem 4rem;
+    }
+
+    @media ${device.mobile} {
+      margin-top: ${HEADER_HEIGHT.MOBILE};
+      padding: 4rem 0;
+    }
+  `,
+  ContentBox: styled.div`
+    max-width: 93rem;
+    max-height: 73.2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10rem;
+    position: relative;
+    background-color: green;
+
+    @media ${device.tablet} {
+      flex-direction: column;
+      max-height: none;
+      max-width: none;
+      justify-content: center;
+    }
+  `,
+  BookShelf: styled.div`
+    background-color: orange;
+    min-width: 20.9rem;
+    min-height: 44rem;
+    width: 20.9rem;
+    height: 44rem;
+  `,
+  Book: styled.div`
+    min-width: 50rem;
+    min-height: 54rem;
+    width: 48.5rem;
+    height: 54rem;
+    background-color: yellow;
+
+    @media ${device.tablet} {
+      min-width: 43rem;
+      min-height: 46.5rem;
+      width: 43rem;
+      height: 46.5rem;
+    }
+
+    @media ${device.mobile} {
+      min-width: 30rem;
+      min-height: 45.5rem;
+      width: 30rem;
+      height: 45.5rem;
+    }
+  `,
+  GoBackButtonLayout: styled.div`
+    position: absolute;
+    bottom: -5rem;
+  `,
+};

--- a/src/pages/ReadBook/index.tsx
+++ b/src/pages/ReadBook/index.tsx
@@ -1,25 +1,26 @@
+import { useBookDetail } from '@hooks/reactQuery/useQueryBook';
 import BookScollPaper from '@pages/main/components/bookshelf/BookScollPaper';
 import GoBackButton from '@pages/myPage/components/profileSection/components/GoBackButton';
 import { skeletonAnimation } from '@styles/animation/skeletonAnimation';
 import { device } from '@styles/breakpoints';
 import { HEADER_HEIGHT } from '@styles/headerHeight';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 
 const ReadBook = () => {
   const navigate = useNavigate();
+  const bookId = useParams();
+  const { data } = useBookDetail(Number(bookId.id));
 
   return (
     <S.Container>
       <S.ContentBox>
-        <S.BookShelf />
+        <S.BookShelf src={data?.bookImageUrl} />
         <S.Book>
           <BookScollPaper
-            ownerName={'여섯글자유저'}
-            content={
-              '아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구아버지를 아버지라 부르지 못하고 어쩌구'
-            }
-            sender={'신나는토끼'}
+            ownerName={data ? data.receiverNickname : ''}
+            content={data ? data.description : ''}
+            sender={data ? data.senderNickname : ''}
             isPreview={false}
           />
         </S.Book>

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -5,7 +5,8 @@ import Login from '@pages/Login';
 import Main from '@pages/main';
 import MyPage from '@pages/myPage';
 import NotFound from '@pages/notFound';
+import ReadBook from '@pages/ReadBook';
 import Root from '@pages/Root';
 import SetUp from '@pages/setup';
 
-export { Home, Root, Login, SetUp, Main, Auth, Landing, MyPage, NotFound };
+export { Home, Root, Login, SetUp, Main, Auth, Landing, MyPage, NotFound, ReadBook };

--- a/src/pages/main/components/bookshelf/BookScollPaper.tsx
+++ b/src/pages/main/components/bookshelf/BookScollPaper.tsx
@@ -1,4 +1,5 @@
 import { device } from '@styles/breakpoints';
+import { light } from '@styles/theme/light';
 import styled, { keyframes } from 'styled-components';
 
 interface TBookScollPaperProps {
@@ -97,8 +98,8 @@ const S = {
       background: linear-gradient(to top, #ceb499 0%, #bb9165 100%);
       background: linear-gradient(
         to top,
-        ${({ theme }) => theme.bookscrollBarTop} 0%,
-        ${({ theme }) => theme.bookscrollBarBtm} 100%
+        ${({ theme }) => theme.bookscrollBarTop || light.bookscrollBarTop} 0%,
+        ${({ theme }) => theme.bookscrollBarBtm || light.bookscrollBarBtm} 100%
       );
       left: calc(2%);
       height: 100%;
@@ -110,7 +111,7 @@ const S = {
       display: flex;
       top: calc(50% - 0.8rem / 2);
       width: 100%;
-      background-color: ${({ theme }) => theme.bookscrollBarTip};
+      background-color: ${({ theme }) => theme.bookscrollBarTip || light.bookscrollBarTip};
       height: 0.8rem;
       z-index: 0;
       border-radius: 0.4rem;
@@ -119,8 +120,8 @@ const S = {
 
   BookContent: styled.div<{ $isPreview: boolean }>`
     overflow: hidden;
-    background-color: ${({ theme }) => theme.bookscrollBg};
-    color: ${props => props.theme.bookscrollText};
+    background-color: ${({ theme }) => theme.bookscrollBg || light.bookscrollBg};
+    color: ${({ theme }) => theme.bookscrollText || light.bookscrollText};
     width: calc(100% - 4rem);
     padding: ${({ $isPreview }) => ($isPreview ? '3rem 2.6rem' : '5.6rem 4rem')};
     animation: ${({ $isPreview }) => ($isPreview ? rollDownMobile : rollDown)} 0.5s
@@ -138,7 +139,7 @@ const S = {
     font-size: 2.4rem;
     font-weight: 900;
     p:first-child {
-      color: ${props => props.theme.bookscrollReceiver};
+      color: ${({ theme }) => theme.bookscrollReceiver || light.bookscrollReceiver};
     }
     @media ${device.mobile} {
       font-size: 1.8rem;
@@ -158,7 +159,7 @@ const S = {
       width: 0.4rem;
     }
     &::-webkit-scrollbar-track {
-      background-color: ${props => props.theme.scollBar};
+      background-color: ${({ theme }) => theme.scollBar || light.scollBar};
       border-radius: 0.2rem;
     }
     &::-webkit-scrollbar-thumb {

--- a/src/pages/myPage/components/bookListSection/index.tsx
+++ b/src/pages/myPage/components/bookListSection/index.tsx
@@ -66,7 +66,7 @@ const BookListSection = ({ settingType }: TBookList) => {
         <S.BookButton
           type="button"
           onClick={() => {
-            navigate(`/bookshelf/${book.id}`);
+            navigate(`/book/${book.id}`);
           }}
           key={book.id}>
           <BookInfo bookData={book} settingType={settingType} />

--- a/src/pages/myPage/components/bookListSection/index.tsx
+++ b/src/pages/myPage/components/bookListSection/index.tsx
@@ -26,22 +26,22 @@ const BookListSection = ({ settingType }: TBookList) => {
     setSortingOption(option);
   };
 
-  const { data, isFetching, hasNextPage, fetchNextPage, refetch } = useReceiveSendInfinity({
+  const { data, isLoading, hasNextPage, fetchNextPage, refetch } = useReceiveSendInfinity({
     type: settingType as 'receive' | 'send',
     sortType: sortingOption === '책장 목록 최신 순' ? 'desc' : 'asc',
   });
 
   useEffect(() => {
-    if (isVisible && hasNextPage) {
+    if (isVisible && hasNextPage && !isLoading) {
       fetchNextPage();
     }
-  }, [isVisible, hasNextPage, fetchNextPage]);
+  }, [isVisible, hasNextPage, fetchNextPage, isLoading]);
 
   useEffect(() => {
     refetch();
   }, [refetch, sortingOption]);
 
-  if (!data || isFetching) {
+  if (!data || isLoading) {
     return (
       <BookListSectionLayout
         settingType={settingType}

--- a/src/pages/myPage/components/editSection/components/OpenScopeSection.tsx
+++ b/src/pages/myPage/components/editSection/components/OpenScopeSection.tsx
@@ -10,7 +10,7 @@ const OpenScopeSection = ({ open }: { open: boolean | undefined }) => {
   const patchOpenScope = useBookshelfPublicityUpdateMutation();
 
   useEffect(() => {
-    if (open) {
+    if (open !== undefined) {
       handleInitialSetScope(open);
     }
 


### PR DESCRIPTION
## 🚀 작업 내용
- 공개 여부가 UI에 제대로 적용되지 않는 문제 해결
- 무한 스크롤 무한 패칭 해결
- 남긴 방명록, 보낸 방명록 상세보기 페이지 구현

## 📝 참고 사항
- ScrollPaper을 가져다가 사용하고 있는데 모바일 UI 부분이 많이 다른 것 같아서 수정해야할 것 같습니다.

## 🖼️ 스크린샷
![보낸, 받은 방명록 상세보기](https://github.com/user-attachments/assets/c56f9d6c-8a5d-448a-9397-2f7ec27bc362)



## 🚨 관련 이슈

- 
